### PR TITLE
Configure Terraform pipeline to use MinIO backend

### DIFF
--- a/pipeline/pipeline.jenkins
+++ b/pipeline/pipeline.jenkins
@@ -8,6 +8,13 @@ pipeline {
             error 'AUTO_APPROVE parameter is not set'
           }
 
+          def backendConfig = params.get('BACKEND_CONFIG_FILE', "${env.HOME}/.tfvars/minio.backend.hcl")
+          if (!backendConfig?.trim()) {
+            error 'BACKEND_CONFIG_FILE parameter is not set'
+          }
+          sh "test -f '${backendConfig}'"
+          env.BACKEND_CONFIG_FILE = backendConfig
+
           def files = [
             DOCKER_TFVARS_FILE: params.DOCKER_TFVARS_FILE,
             APP_TFVARS_FILE   : params.APP_TFVARS_FILE
@@ -24,7 +31,7 @@ pipeline {
     stage('Docker') {
       steps {
         script {
-          sh 'terraform -chdir=docker init -input=false'
+          sh "terraform -chdir=docker init -input=false -backend-config='${env.BACKEND_CONFIG_FILE}'"
           if (params.AUTO_APPROVE) {
             sh "terraform -chdir=docker apply -input=false -auto-approve -var-file=${params.DOCKER_TFVARS_FILE}"
           } else {

--- a/pipeline/pipeline.sh
+++ b/pipeline/pipeline.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 TFVARS_PATH="$HOME/.tfvars/docker_swarm.tfvars"
+BACKEND_CONFIG_PATH="$HOME/.tfvars/minio.backend.hcl"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
@@ -10,11 +11,13 @@ command -v terraform >/dev/null 2>&1 || { echo "[ERR] terraform not found in PAT
 echo "[STAGE 0] verify params"
 [[ -n "$TFVARS_PATH" ]] || { echo "[ERR] TFVARS_PATH is not set" >&2; exit 1; }
 [[ -f "$TFVARS_PATH" ]] || { echo "[ERR] TFVARS_PATH file not found: $TFVARS_PATH" >&2; exit 1; }
+[[ -n "$BACKEND_CONFIG_PATH" ]] || { echo "[ERR] BACKEND_CONFIG_PATH is not set" >&2; exit 1; }
+[[ -f "$BACKEND_CONFIG_PATH" ]] || { echo "[ERR] BACKEND_CONFIG_PATH file not found: $BACKEND_CONFIG_PATH" >&2; exit 1; }
 
 apply_dir() {
   local TFVARS="$1"
   echo "[STEP] terraform init"
-  terraform init -input=false
+  terraform init -input=false -backend-config="$BACKEND_CONFIG_PATH"
 
   echo "[STEP] terraform plan"
   terraform plan -input=false ${TFVARS:+-var-file="$TFVARS"}

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,6 @@
 terraform {
+  backend "s3" {}
+
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
## Summary
- add an s3 backend block so Terraform can target the MinIO state bucket
- update the Jenkins pipeline to validate a backend config file and pass it to terraform init
- update the helper shell pipeline to reuse the MinIO backend config during init

## Testing
- not run (terraform CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d096c77d28832c95f9c3c64ef3ebaf