### PR TITLE
Add option to purge swarm services

### DIFF
--- a/purge.sh
+++ b/purge.sh
@@ -12,14 +12,16 @@ WARN_DRAIN="--drain will stop and remove ALL containers on this node (including 
 force=false
 drain=false
 restart=false
+services=false
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--force] [--drain] [--restart]
+Usage: $(basename "$0") [--force] [--drain] [--services] [--restart]
 
   --force     Skip interactive confirmation.
   --drain     (Manager node only) Temporarily set this node to DRAIN, stop/remove ALL containers,
               prune everything, then restore previous availability. Keeps node in the swarm.
+  --services  (Manager node only) Remove ALL swarm services on this node after cleanup.
   --restart   Restart the Docker daemon at the end (systemd environments).
 
 Notes:
@@ -30,9 +32,10 @@ EOF
 
 for arg in "${@:-}"; do
   case "$arg" in
-    --force)   force=true ;;
-    --drain)   drain=true ;;
-    --restart) restart=true ;;
+    --force)    force=true ;;
+    --drain)    drain=true ;;
+    --services) services=true ;;
+    --restart)  restart=true ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $arg" >&2; usage; exit 1 ;;
   esac
@@ -61,6 +64,11 @@ if $is_in_swarm; then
   [[ "$ctrl" == "true" ]] && { role="manager"; is_manager=true; }
 fi
 
+if $services && ! $is_manager; then
+  echo "ERROR: --services requires running on a swarm MANAGER." >&2
+  exit 1
+fi
+
 echo "==> Swarm: $($is_in_swarm && echo "JOINED ($role)" || echo "not joined")"
 
 echo
@@ -69,12 +77,18 @@ echo "  • Stop & remove ALL standalone containers (not created by swarm)."
 if $drain; then
   echo "  • (DRAIN MODE) Stop & remove ALL containers (including swarm tasks) on this node."
 fi
+if $services; then
+  echo "  • Remove ALL swarm services."
+fi
 echo "  • Prune UNUSED images, volumes, networks, and builder cache."
 echo "  • Preserve swarm membership (no 'docker swarm leave', no deletion of /var/lib/docker/swarm)."
 echo
 echo "Caveats:"
 echo "  • ${WARN_VOL}"
 $drain && echo "  • ${WARN_DRAIN}"
+if $services; then
+  echo "  • Removes all swarm services from the manager."
+fi
 echo
 
 if [[ $force == false ]]; then
@@ -148,6 +162,16 @@ if $drain; then
     docker node update --availability "$prev_avail" self
   else
     echo "==> Leaving node availability in DRAIN (explicit or unchanged)."
+  fi
+fi
+
+if $services; then
+  echo "==> Removing swarm services..."
+  mapfile -t svc_ids < <(docker service ls -q)
+  if (( ${#svc_ids[@]} )); then
+    docker service rm "${svc_ids[@]}"
+  else
+    echo "    No swarm services present."
   fi
 fi
 


### PR DESCRIPTION
## Summary
- add a --services flag to purge.sh that removes all swarm services when requested
- extend script messaging and safety checks for the new option

## Testing
- bash -n purge.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0a415bd70832cb5ba2b6489006aa1